### PR TITLE
Add game registry and simple wrapper for game state management

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Now you can visit [`localhost:4000`](http://localhost:4000) from your browser.
 
 Ready to run in production? Please [check our deployment guides](http://www.phoenixframework.org/docs/deployment).
 
-### Learn more
+### Learn More
 
   * Official website: http://www.phoenixframework.org/
   * Guides: http://phoenixframework.org/docs/overview

--- a/lib/wikitrivia/application.ex
+++ b/lib/wikitrivia/application.ex
@@ -14,6 +14,7 @@ defmodule Wikitrivia.Application do
       supervisor(WikitriviaWeb.Endpoint, []),
       # Start your own worker by calling: Wikitrivia.Worker.start_link(arg1, arg2, arg3)
       # worker(Wikitrivia.Worker, [arg1, arg2, arg3]),
+      {Registry, keys: :unique, name: Registry.Games}
     ]
 
     # See https://hexdocs.pm/elixir/Supervisor.html

--- a/lib/wikitrivia/game.ex
+++ b/lib/wikitrivia/game.ex
@@ -1,0 +1,46 @@
+defmodule Wikitrivia.Game do
+  def create_game do
+    game_id = Ecto.UUID.generate
+    {:ok, _} = Agent.start_link(fn -> default_state end, name: agent_name_by_game_id(game_id))
+    game_id
+  end
+
+  def get_game_state(game_id) do
+    Agent.get(agent_name_by_game_id(game_id), fn s -> s end)
+  end
+
+  def add_player(game_id, player_id, player_name) do
+    Agent.update(agent_name_by_game_id(game_id), add_player(player_id, player_name))
+  end
+
+  def award_points(game_id, player_id, points) do
+    Agent.update(agent_name_by_game_id(game_id), award_points(player_id, points))
+  end
+
+  defp default_state do
+    %{
+      players: %{},
+      scores: %{}
+    }
+  end
+
+  defp add_player(player_id, player_name) do
+    fn (state = %{players: players, scores: scores}) ->
+      players = players |> Map.put(player_id, player_name)
+      scores = scores |> Map.put(player_id, 0)
+      %{state | players: players, scores: scores}
+    end
+  end
+
+  defp award_points(player_id, points) do
+    fn (state = %{scores: scores}) ->
+      %{^player_id => player_score} = scores
+      new_score = player_score + points
+      %{state | scores: %{scores | player_id => new_score}}
+    end
+  end
+
+  defp agent_name_by_game_id(game_id) do
+    {:via, Registry, {Registry.Games, game_id}}
+  end
+end

--- a/lib/wikitrivia/game.ex
+++ b/lib/wikitrivia/game.ex
@@ -9,34 +9,34 @@ defmodule Wikitrivia.Game do
     Agent.get(agent_name_by_game_id(game_id), fn s -> s end)
   end
 
-  def add_player(game_id, player_id, player_name) do
-    Agent.update(agent_name_by_game_id(game_id), add_player(player_id, player_name))
+  def add_player(game_id, player_name) do
+    Agent.update(agent_name_by_game_id(game_id), add_player(player_name))
   end
 
-  def award_points(game_id, player_id, points) do
-    Agent.update(agent_name_by_game_id(game_id), award_points(player_id, points))
+  def award_points(game_id, player_name, points) do
+    Agent.update(agent_name_by_game_id(game_id), award_points(player_name, points))
   end
 
   defp default_state do
     %{
-      players: %{},
+      players: MapSet.new(),
       scores: %{}
     }
   end
 
-  defp add_player(player_id, player_name) do
+  defp add_player(player_name) do
     fn (state = %{players: players, scores: scores}) ->
-      players = players |> Map.put(player_id, player_name)
-      scores = scores |> Map.put(player_id, 0)
+      players = players |> MapSet.put(player_name)
+      scores = scores |> Map.put(player_name, 0)
       %{state | players: players, scores: scores}
     end
   end
 
-  defp award_points(player_id, points) do
+  defp award_points(player_name, points) do
     fn (state = %{scores: scores}) ->
-      %{^player_id => player_score} = scores
+      %{^player_name => player_score} = scores
       new_score = player_score + points
-      %{state | scores: %{scores | player_id => new_score}}
+      %{state | scores: %{scores | player_name => new_score}}
     end
   end
 

--- a/test/wikitrivia/game_test.exs
+++ b/test/wikitrivia/game_test.exs
@@ -7,32 +7,32 @@ defmodule Wikitrivia.GameTest do
     game_id = Game.create_game()
     initial_state = Game.get_game_state(game_id)
     assert initial_state == %{
-      players: %{},
+      players: MapSet.new(),
       scores: %{}
     }
   end
 
   test "adds new players" do
     game_id = Game.create_game()
-    Game.add_player(game_id, 1, "Alex")
+    Game.add_player(game_id, "Alex")
     %{players: players, scores: scores} = Game.get_game_state(game_id)
-    assert players == %{1 => "Alex"}
-    assert scores == %{1 => 0}
-    Game.add_player(game_id, 2, "Dennis")
+    assert players == MapSet.new() |> MapSet.put("Alex")
+    assert scores == %{"Alex" => 0}
+    Game.add_player(game_id, "Dennis")
     %{players: players, scores: scores} = Game.get_game_state(game_id)
-    assert players == %{1 => "Alex", 2 => "Dennis"}
-    assert scores == %{1 => 0, 2 => 0}
+    assert players == MapSet.new() |> MapSet.put("Alex") |> MapSet.put("Dennis")
+    assert scores == %{"Alex" => 0, "Dennis" => 0}
   end
 
   test "awards points" do
     game_id = Game.create_game()
-    Game.add_player(game_id, 1, "Alex")
-    Game.add_player(game_id, 2, "Dennis")
-    Game.award_points(game_id, 2, 100)
+    Game.add_player(game_id, "Alex")
+    Game.add_player(game_id, "Dennis")
+    Game.award_points(game_id, "Dennis", 100)
     %{scores: scores} = Game.get_game_state(game_id)
-    assert scores == %{1 => 0, 2 => 100}
-    Game.award_points(game_id, 2, 250)
+    assert scores == %{"Alex" => 0, "Dennis" => 100}
+    Game.award_points(game_id, "Dennis", 250)
     %{scores: scores} = Game.get_game_state(game_id)
-    assert scores == %{1 => 0, 2 => 350}
+    assert scores == %{"Alex" => 0, "Dennis" => 350}
   end
 end

--- a/test/wikitrivia/game_test.exs
+++ b/test/wikitrivia/game_test.exs
@@ -1,0 +1,38 @@
+defmodule Wikitrivia.GameTest do
+  alias Wikitrivia.Game
+
+  use ExUnit.Case
+
+  test "starts a game with default state" do
+    game_id = Game.create_game()
+    initial_state = Game.get_game_state(game_id)
+    assert initial_state == %{
+      players: %{},
+      scores: %{}
+    }
+  end
+
+  test "adds new players" do
+    game_id = Game.create_game()
+    Game.add_player(game_id, 1, "Alex")
+    %{players: players, scores: scores} = Game.get_game_state(game_id)
+    assert players == %{1 => "Alex"}
+    assert scores == %{1 => 0}
+    Game.add_player(game_id, 2, "Dennis")
+    %{players: players, scores: scores} = Game.get_game_state(game_id)
+    assert players == %{1 => "Alex", 2 => "Dennis"}
+    assert scores == %{1 => 0, 2 => 0}
+  end
+
+  test "awards points" do
+    game_id = Game.create_game()
+    Game.add_player(game_id, 1, "Alex")
+    Game.add_player(game_id, 2, "Dennis")
+    Game.award_points(game_id, 2, 100)
+    %{scores: scores} = Game.get_game_state(game_id)
+    assert scores == %{1 => 0, 2 => 100}
+    Game.award_points(game_id, 2, 250)
+    %{scores: scores} = Game.get_game_state(game_id)
+    assert scores == %{1 => 0, 2 => 350}
+  end
+end


### PR DESCRIPTION
@denheck I'm not especially attached to this particular game state structure, it's probably a bit more complex than we'll end up actually needing. We could probably get away with using the names provided by the players as their ids. (maybe. we'd have to decide if we triggered the join game/add player behavior when the player arrives at the game page, or after they have input a player name. if the former, we may want to just generate an id for them and let them set a name to go along with that id later)